### PR TITLE
Update .gitignore with *.mexa64 to support RHEL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 
 #Compiled files
 *.mexw64
+*.mexa64
 *.mexmaci64
 *.exe
 *.obj


### PR DESCRIPTION
On 64-bit RHEL Linux, the compiled MEXes have a `.mexa64` extension, which is not currently ignored by git.

This PR adds the appropriate `.gitignore` entry